### PR TITLE
Add Azure-focused single LimeSurvey 6 Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Dockerfile to build a [LimeSurvey](https://limesurvey.org) Image for the Docker 
 - [`5-fpm`, `5.<BUILD-NUMBER>-fpm`](https://github.com/martialblog/docker-limesurvey/blob/master/5.0/fpm/Dockerfile)
 - [`5-fpm-alpine`, `5.<BUILD-NUMBER>-fpm-alpine`](https://github.com/martialblog/docker-limesurvey/blob/master/5.0/fpm-alpine/Dockerfile)
 
+## Azure-friendly single Dockerfile
+
+This branch adds an opinionated Dockerfile located in [`azure/Dockerfile`](azure/Dockerfile)
+that bakes LimeSurvey 6.0 together with the Microsoft SQL Server ODBC driver and
+a connection-string driven entrypoint. See [`azure/README.md`](azure/README.md)
+for details and Azure deployment hints.
+
 # Using the Apache Image
 
 The `apache` image comes with an Apache Webserver and PHP installed.

--- a/azure/Dockerfile
+++ b/azure/Dockerfile
@@ -1,0 +1,120 @@
+# Single LimeSurvey 6.0 image configured via a DB connection string
+FROM php:8.2-apache-bookworm
+
+LABEL maintainer="Codex Automation <codex@example.com>"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install base OS dependencies
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg2 \
+        netcat-openbsd \
+        unzip \
+        libldap-common \
+        libsasl2-modules; \
+    rm -rf /var/lib/apt/lists/*
+
+# Add Microsoft package repository for the SQL Server ODBC driver
+RUN set -eux; \
+    curl -sSL https://packages.microsoft.com/keys/microsoft.asc | \
+        gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg; \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" > /etc/apt/sources.list.d/microsoft-prod.list
+
+# Install PHP extensions and SQL Server ODBC driver
+RUN set -eux; \
+    savedAptMark="$(apt-mark showmanual)"; \
+    apt-get update; \
+    ACCEPT_EULA=Y apt-get install -y --no-install-recommends \
+        unixodbc \
+        unixodbc-dev \
+        msodbcsql18 \
+        libldap2-dev \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libonig-dev \
+        libpng-dev \
+        libpq-dev \
+        libzip-dev \
+        libtidy-dev \
+        libsodium-dev; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-install -j"$(nproc)" \
+        exif \
+        gd \
+        ldap \
+        mbstring \
+        pdo \
+        pdo_mysql \
+        pdo_pgsql \
+        pgsql \
+        sodium \
+        tidy \
+        zip; \
+    pecl install sqlsrv pdo_sqlsrv; \
+    docker-php-ext-enable sqlsrv pdo_sqlsrv; \
+    apt-mark manual msodbcsql18 unixodbc; \
+    apt-mark auto '.*' > /dev/null; \
+    apt-mark manual $savedAptMark msodbcsql18 unixodbc; \
+    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+        | awk '/=>/ { print $3 }' \
+        | sort -u \
+        | xargs -r dpkg-query -S \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -rt apt-mark manual; \
+    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+        | awk '$3 ~ /^\/lib/ { print "/usr"$3 }' \
+        | sort -u \
+        | xargs -r dpkg-query -S \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -rt apt-mark manual; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+# Apache configuration adjustments
+RUN set -eux; \
+    a2enmod headers rewrite remoteip; \
+    { \
+        echo 'RemoteIPHeader X-Forwarded-For'; \
+        echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+        echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+        echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+    } > /etc/apache2/conf-available/remoteip.conf; \
+    a2enconf remoteip; \
+    mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+ARG LS_VERSION="6.15.11+250909"
+ARG LS_SHA256="02f2f3125c20a5ebee1e6ec8beebf2e722cdf933d6c7e9ef8578484073b5fa94"
+ARG LS_ARCHIVE_URL="https://github.com/LimeSurvey/LimeSurvey/archive/refs/tags/${LS_VERSION}.tar.gz"
+ENV LIMESURVEY_VERSION=${LS_VERSION}
+
+# Download LimeSurvey and prepare filesystem
+RUN set -eux; \
+    curl -sSL "${LS_ARCHIVE_URL}" --output /tmp/limesurvey.tar.gz; \
+    echo "${LS_SHA256}  /tmp/limesurvey.tar.gz" | sha256sum -c -; \
+    tar xzf /tmp/limesurvey.tar.gz --strip-components=1 -C /var/www/html/; \
+    rm -f /tmp/limesurvey.tar.gz; \
+    chown -R www-data:www-data /var/www/html /etc/apache2
+
+WORKDIR /var/www/html
+
+COPY azure/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY azure/connection-string-parser.php /usr/local/bin/connection-string-parser.php
+COPY azure/vhosts-access-log.conf /etc/apache2/conf-enabled/other-vhosts-access-log.conf
+
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/connection-string-parser.php
+
+USER www-data
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/azure/README.md
+++ b/azure/README.md
@@ -1,0 +1,68 @@
+# LimeSurvey 6 Azure-friendly Dockerfile
+
+This folder contains a self-contained Dockerfile that builds a LimeSurvey 6.0 image
+which relies on a single mandatory environment variable: `DB_CONNECTION_STRING`.
+The image targets automated deployments (e.g. Terraform on Azure) where the
+container receives the full database connection string from platform secrets.
+
+## Highlights
+
+- Based on `php:8.2-apache-bookworm` and bundles LimeSurvey `6.15.11+250909`.
+- Installs Microsoft's ODBC driver plus the `pdo_sqlsrv` PHP extension so Azure
+  SQL Database connection strings work out-of-the-box.
+- Generates `config.php` dynamically from the connection string and performs the
+  CLI-driven LimeSurvey installation on first start.
+- Auto-generates an admin password (logged once) when `ADMIN_PASSWORD` is not
+  provided, keeping the connection string as the only required input.
+
+## Usage
+
+```bash
+docker build -f azure/Dockerfile -t limesurvey-azure .
+
+docker run -p 8080:8080 \
+  -e "DB_CONNECTION_STRING=Server=tcp:myserver.database.windows.net,1433;Database=limesurvey;Uid=lsadmin@myserver;Pwd=S3cretPass!;Encrypt=yes;TrustServerCertificate=no;" \
+  limesurvey-azure
+```
+
+When the container provisions LimeSurvey for the first time it will:
+
+1. Wait until the target database endpoint is reachable (if host/port were
+   present in the connection string).
+2. Generate `/var/www/html/application/config/config.php` using the parsed
+   credentials.
+3. Execute the LimeSurvey CLI installer. If no admin password was provided, a
+   strong random password is generated and printed to the logs.
+
+Persist volumes as required for uploads, e.g. `-v limesurvey-upload:/var/www/html/upload`.
+
+## Connection string formats
+
+The parser accepts common styles:
+
+- Standard Azure SQL style: `Server=tcp:...;Database=...;User ID=...;Password=...`.
+- PDO DSN style: `sqlsrv:Server=...;Database=...;Uid=...;Pwd=...`.
+- Generic URL style: `mysql://user:pass@host:3306/database?charset=utf8mb4`.
+
+Username and password can be embedded in the string. If they are not present,
+provide them separately via optional `ADMIN_*` variables or extend the string.
+
+## Customisation knobs
+
+While `DB_CONNECTION_STRING` is the only required variable, the entrypoint also
+respects optional overrides:
+
+- `LISTEN_PORT` – change Apache's internal listen port (defaults to 8080).
+- `PUBLIC_URL`, `BASE_URL`, `URL_FORMAT`, `SHOW_SCRIPT_NAME`, `DEBUG`, `DEBUG_SQL`
+  – forwarded to LimeSurvey configuration when present.
+- `ADMIN_USER`, `ADMIN_PASSWORD`, `ADMIN_NAME`, `ADMIN_EMAIL` – optional initial
+  admin credentials.
+
+## Terraform & Azure deployment notes
+
+- Store `DB_CONNECTION_STRING` in Azure Key Vault or as a Kubernetes secret and
+  inject it into the container instance.
+- Make sure the LimeSurvey upload directory is persisted (Azure Files, managed
+  disk, or blobfuse) to keep themes and survey assets across restarts.
+- Configure outbound firewall rules so the container can reach the Azure SQL
+  endpoint port (typically 1433).

--- a/azure/connection-string-parser.php
+++ b/azure/connection-string-parser.php
@@ -1,0 +1,370 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+final class ConnectionStringParser
+{
+    private string $raw;
+
+    public function __construct(string $connectionString)
+    {
+        $this->raw = trim($connectionString);
+        if ($this->raw === '') {
+            throw new InvalidArgumentException('Empty connection string received.');
+        }
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function parse(): array
+    {
+        if ($this->looksLikeUrlStyle()) {
+            return $this->parseUrlStyle();
+        }
+
+        if ($this->looksLikeKeyValueStyle()) {
+            return $this->parseKeyValueStyle();
+        }
+
+        if ($this->looksLikeDsnStyle()) {
+            return $this->parseDsnStyle();
+        }
+
+        throw new InvalidArgumentException('Unsupported connection string format.');
+    }
+
+    private function looksLikeUrlStyle(): bool
+    {
+        return (bool)preg_match('/^[a-z][a-z0-9+.-]*:\/\//i', $this->raw);
+    }
+
+    private function looksLikeKeyValueStyle(): bool
+    {
+        return str_contains($this->raw, '=') && str_contains($this->raw, ';');
+    }
+
+    private function looksLikeDsnStyle(): bool
+    {
+        return (bool)preg_match('/^[a-z][a-z0-9+.-]*:/i', $this->raw);
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function parseUrlStyle(): array
+    {
+        $url = parse_url($this->raw);
+        if ($url === false || empty($url['scheme'])) {
+            throw new InvalidArgumentException('Malformed URL style connection string.');
+        }
+
+        $scheme = strtolower($url['scheme']);
+        $driver = $this->normalizeDriver($scheme);
+
+        $host = $url['host'] ?? '';
+        $port = isset($url['port']) ? (string)$url['port'] : '';
+        $db = isset($url['path']) ? ltrim($url['path'], '/') : '';
+        $user = $url['user'] ?? '';
+        $pass = $url['pass'] ?? '';
+
+        $params = [];
+        if (!empty($url['query'])) {
+            parse_str($url['query'], $queryParams);
+            foreach ($queryParams as $key => $value) {
+                if ($value === '') {
+                    continue;
+                }
+                $params[] = sprintf('%s=%s', $key, $value);
+            }
+        }
+
+        $dsn = $this->buildDsn($driver, $host, $port, $db, $params);
+
+        return [
+            'DB_DRIVER' => $driver,
+            'DB_DSN' => $dsn,
+            'DB_HOST' => $host,
+            'DB_PORT' => $port,
+            'DB_DATABASE' => $db,
+            'DB_USERNAME' => $user,
+            'DB_PASSWORD' => $pass,
+        ];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function parseDsnStyle(): array
+    {
+        [$driverRaw] = explode(':', $this->raw, 2);
+        $driver = $this->normalizeDriver($driverRaw);
+
+        // Attempt to extract key pieces from DSN (best effort)
+        $host = '';
+        $port = '';
+        $db = '';
+        $dsn = $this->raw;
+
+        $segments = explode(';', $dsn);
+        foreach ($segments as $segment) {
+            if (!str_contains($segment, '=')) {
+                continue;
+            }
+            [$key, $value] = array_map('trim', explode('=', $segment, 2));
+            $lowerKey = strtolower($key);
+            if ($host === '' && in_array($lowerKey, ['host', 'server', 'servername'], true)) {
+                $host = $value;
+                if (str_contains($host, ',')) {
+                    [$host, $possiblePort] = array_map('trim', explode(',', $host, 2));
+                    if ($port === '') {
+                        $port = $possiblePort;
+                    }
+                }
+            }
+            if ($port === '' && in_array($lowerKey, ['port'], true)) {
+                $port = $value;
+            }
+            if ($db === '' && in_array($lowerKey, ['dbname', 'database', 'initial catalog'], true)) {
+                $db = $value;
+            }
+        }
+
+        return [
+            'DB_DRIVER' => $driver,
+            'DB_DSN' => $dsn,
+            'DB_HOST' => $host,
+            'DB_PORT' => $port,
+            'DB_DATABASE' => $db,
+            'DB_USERNAME' => '',
+            'DB_PASSWORD' => '',
+        ];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function parseKeyValueStyle(): array
+    {
+        $tokens = [];
+        foreach (explode(';', $this->raw) as $segment) {
+            $segment = trim($segment);
+            if ($segment === '') {
+                continue;
+            }
+            [$key, $value] = array_map('trim', explode('=', $segment, 2));
+            if ($key === '') {
+                continue;
+            }
+            $value = trim($value, " \t\n\r\0\x0B\"");
+            if (str_starts_with($value, '{') && str_ends_with($value, '}')) {
+                $value = substr($value, 1, -1);
+            }
+            $tokens[] = [
+                'key' => $key,
+                'value' => $value,
+                'lower' => strtolower($key),
+            ];
+        }
+
+        $map = [];
+        foreach ($tokens as $token) {
+            $map[$token['lower']] = $token['value'];
+        }
+
+        $driverHint = $map['dbtype']
+            ?? $map['provider']
+            ?? $map['driver']
+            ?? '';
+        $driver = $this->normalizeDriver($driverHint ?: 'sqlsrv');
+
+        $hostValue = $this->firstNonEmpty($map, ['server', 'data source', 'datasource', 'address', 'addr', 'network address', 'host']);
+        $port = $this->firstNonEmpty($map, ['port']);
+        if ($hostValue !== null) {
+            $hostValue = $this->normalizeServer($hostValue, $port);
+            [$hostValue, $derivedPort] = $hostValue;
+            if ($port === null && $derivedPort !== '') {
+                $port = $derivedPort;
+            }
+            $host = $hostValue;
+        } else {
+            $host = '';
+        }
+        $port = $port ?? '';
+
+        $database = $this->firstNonEmpty($map, ['database', 'initial catalog', 'dbname', 'catalog']) ?? '';
+        $username = $this->firstNonEmpty($map, ['uid', 'user id', 'userid', 'username', 'user']) ?? '';
+        $password = $this->firstNonEmpty($map, ['pwd', 'password']) ?? '';
+
+        $consumedKeys = [
+            'dbtype', 'provider', 'driver',
+            'server', 'data source', 'datasource', 'address', 'addr', 'network address', 'host',
+            'port', 'database', 'initial catalog', 'dbname', 'catalog',
+            'uid', 'user id', 'userid', 'username', 'user',
+            'pwd', 'password',
+        ];
+        $extraParams = [];
+        foreach ($tokens as $token) {
+            if (!in_array($token['lower'], $consumedKeys, true) && $token['value'] !== '') {
+                $extraParams[] = $token;
+            }
+        }
+
+        $extraParts = [];
+        foreach ($extraParams as $param) {
+            $extraParts[] = sprintf('%s=%s', $param['key'], $param['value']);
+        }
+
+        $dsn = $this->buildDsn($driver, $host, $port, $database, $extraParts);
+
+        return [
+            'DB_DRIVER' => $driver,
+            'DB_DSN' => $dsn,
+            'DB_HOST' => $host,
+            'DB_PORT' => $port,
+            'DB_DATABASE' => $database,
+            'DB_USERNAME' => $username,
+            'DB_PASSWORD' => $password,
+        ];
+    }
+
+    private function normalizeDriver(string $hint): string
+    {
+        $hint = strtolower(trim($hint));
+        if ($hint === '') {
+            return 'sqlsrv';
+        }
+
+        return match (true) {
+            str_starts_with($hint, 'mysql'), str_contains($hint, 'mariadb') => 'mysql',
+            str_starts_with($hint, 'pgsql'), str_contains($hint, 'postgres') => 'pgsql',
+            str_starts_with($hint, 'sqlsrv'), str_contains($hint, 'sql server'), str_contains($hint, 'odbc driver') => 'sqlsrv',
+            default => $hint,
+        };
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    private function normalizeServer(string $value, ?string $portHint): array
+    {
+        $clean = trim($value);
+        if (stripos($clean, 'tcp:') === 0) {
+            $clean = substr($clean, 4);
+        }
+
+        $derivedPort = $portHint ?? '';
+        if (str_contains($clean, ',')) {
+            [$clean, $possiblePort] = array_map('trim', explode(',', $clean, 2));
+            if ($derivedPort === '' && $possiblePort !== '') {
+                $derivedPort = $possiblePort;
+            }
+        }
+
+        return [$clean, $derivedPort];
+    }
+
+    /**
+     * @param array<string,string> $map
+     * @param array<int,string> $keys
+     */
+    private function firstNonEmpty(array $map, array $keys): ?string
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $map)) {
+                continue;
+            }
+            $value = trim((string)$map[$key]);
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<string> $extraParts
+     */
+    private function buildDsn(string $driver, string $host, string $port, string $database, array $extraParts): string
+    {
+        $dsn = sprintf('%s:', $driver);
+        $segments = [];
+
+        if ($driver === 'sqlsrv') {
+            if ($host !== '') {
+                $server = $host;
+                if ($port !== '') {
+                    $server .= ',' . $port;
+                }
+                $segments[] = 'Server=' . $server;
+            }
+            if ($database !== '') {
+                $segments[] = 'Database=' . $database;
+            }
+            $hasCharacterSet = false;
+            foreach ($extraParts as $part) {
+                if (str_starts_with(strtolower($part), 'characterset=')) {
+                    $hasCharacterSet = true;
+                    break;
+                }
+            }
+            if (!$hasCharacterSet) {
+                $extraParts[] = 'CharacterSet=UTF-8';
+            }
+        } else {
+            if ($host !== '') {
+                $segments[] = 'host=' . $host;
+            }
+            if ($port !== '') {
+                $segments[] = 'port=' . $port;
+            }
+            if ($database !== '') {
+                $segments[] = 'dbname=' . $database;
+            }
+        }
+
+        if ($driver === 'mysql' && !self::containsKey($extraParts, 'charset')) {
+            $extraParts[] = 'charset=utf8mb4';
+        }
+
+        $segments = array_filter($segments, fn($segment) => $segment !== '');
+        $dsn .= implode(';', $segments);
+
+        if (!empty($extraParts)) {
+            if (!empty($segments)) {
+                $dsn .= ';';
+            }
+            $dsn .= implode(';', $extraParts);
+        }
+
+        return $dsn;
+    }
+
+    /**
+     * @param list<string> $extraParts
+     */
+    private static function containsKey(array $extraParts, string $key): bool
+    {
+        $needle = strtolower($key) . '=';
+        foreach ($extraParts as $part) {
+            if (str_starts_with(strtolower($part), $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+try {
+    $connectionString = getenv('DB_CONNECTION_STRING') ?: ($argv[1] ?? '');
+    $parser = new ConnectionStringParser($connectionString);
+    $result = $parser->parse();
+    foreach ($result as $key => $value) {
+        printf("%s=%s\n", $key, $value);
+    }
+} catch (Throwable $exception) {
+    fwrite(STDERR, 'Unable to parse DB_CONNECTION_STRING: ' . $exception->getMessage() . PHP_EOL);
+    exit(1);
+}

--- a/azure/entrypoint.sh
+++ b/azure/entrypoint.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+set -euo pipefail
+
+log() {
+    printf '%s %s\n' "[entrypoint]" "$*"
+}
+
+if [[ -z "${DB_CONNECTION_STRING:-}" ]]; then
+    echo "Error: DB_CONNECTION_STRING environment variable is required." >&2
+    exit 1
+fi
+
+LISTEN_PORT=${LISTEN_PORT:-8080}
+if [[ "$LISTEN_PORT" != "80" ]]; then
+    log "Configuring Apache listen port to $LISTEN_PORT"
+    sed -i "s/Listen 80\$/Listen $LISTEN_PORT/" /etc/apache2/ports.conf
+    sed -i "s/<VirtualHost \*:80>/<VirtualHost *:$LISTEN_PORT>/" /etc/apache2/sites-available/000-default.conf
+fi
+
+parse_output=()
+while IFS= read -r line; do
+    parse_output+=("$line")
+done < <(DB_CONNECTION_STRING="$DB_CONNECTION_STRING" /usr/local/bin/connection-string-parser.php)
+
+declare -A DB_PROPS
+for entry in "${parse_output[@]}"; do
+    key=${entry%%=*}
+    value=${entry#*=}
+    DB_PROPS["$key"]=$value
+    case "$key" in
+        DB_PASSWORD)
+            log "$key=******"
+            ;;
+        DB_DSN)
+            log "$key=<hidden>"
+            ;;
+        *)
+            log "$key=${value}"
+            ;;
+    esac
+done
+
+DB_DSN=${DB_PROPS[DB_DSN]:-}
+DB_USERNAME=${DB_PROPS[DB_USERNAME]:-}
+DB_PASSWORD=${DB_PROPS[DB_PASSWORD]:-}
+DB_DRIVER=${DB_PROPS[DB_DRIVER]:-}
+DB_HOST=${DB_PROPS[DB_HOST]:-}
+DB_PORT=${DB_PROPS[DB_PORT]:-}
+DB_DATABASE=${DB_PROPS[DB_DATABASE]:-}
+
+if [[ -z "$DB_DSN" ]]; then
+    echo "Error: Unable to compute PDO DSN from DB_CONNECTION_STRING" >&2
+    exit 1
+fi
+
+DB_CHARSET="utf8"
+if [[ "$DB_DRIVER" == "mysql" ]]; then
+    DB_CHARSET="utf8mb4"
+fi
+
+DB_TABLE_PREFIX=${DB_TABLE_PREFIX:-lime_}
+PUBLIC_URL=${PUBLIC_URL:-}
+BASE_URL=${BASE_URL:-}
+URL_FORMAT=${URL_FORMAT:-path}
+SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-false}
+DEBUG_LEVEL=${DEBUG:-0}
+DEBUG_SQL_LEVEL=${DEBUG_SQL:-0}
+
+export LS_DB_DSN="$DB_DSN"
+export LS_DB_USERNAME="$DB_USERNAME"
+export LS_DB_PASSWORD="$DB_PASSWORD"
+export LS_DB_CHARSET="$DB_CHARSET"
+export LS_DB_TABLE_PREFIX="$DB_TABLE_PREFIX"
+export LS_DB_DRIVER="$DB_DRIVER"
+export LS_PUBLIC_URL="$PUBLIC_URL"
+export LS_BASE_URL="$BASE_URL"
+export LS_URL_FORMAT="$URL_FORMAT"
+export LS_SHOW_SCRIPT_NAME="$SHOW_SCRIPT_NAME"
+export LS_DEBUG_LEVEL="$DEBUG_LEVEL"
+export LS_DEBUG_SQL_LEVEL="$DEBUG_SQL_LEVEL"
+
+if [[ -n "$DB_HOST" && -n "$DB_PORT" ]]; then
+    log "Waiting for database ${DB_HOST}:${DB_PORT}"
+    until nc -z -w5 "$DB_HOST" "$DB_PORT"; do
+        log "Database not reachable yet..."
+        sleep 5
+    done
+fi
+
+CONFIG_PATH="application/config/config.php"
+if [[ ! -f "$CONFIG_PATH" ]]; then
+    log "Generating LimeSurvey config.php"
+    php <<'PHP'
+<?php
+$configPath = 'application/config/config.php';
+$configDir = dirname($configPath);
+if (!is_dir($configDir) && !mkdir($configDir, 0775, true) && !is_dir($configDir)) {
+    fwrite(STDERR, "Unable to create config directory\n");
+    exit(1);
+}
+
+$getenvOrDefault = static function (string $key, string $default = ''): string {
+    $value = getenv($key);
+    if ($value === false) {
+        return $default;
+    }
+    return $value;
+};
+
+$dbConfig = [
+    'connectionString' => $getenvOrDefault('LS_DB_DSN'),
+    'emulatePrepare' => true,
+    'username' => $getenvOrDefault('LS_DB_USERNAME'),
+    'password' => $getenvOrDefault('LS_DB_PASSWORD'),
+    'charset' => $getenvOrDefault('LS_DB_CHARSET'),
+    'tablePrefix' => $getenvOrDefault('LS_DB_TABLE_PREFIX'),
+];
+
+$config = [
+    'components' => [
+        'db' => $dbConfig,
+        'urlManager' => [
+            'urlFormat' => $getenvOrDefault('LS_URL_FORMAT', 'path'),
+            'rules' => [],
+            'showScriptName' => filter_var($getenvOrDefault('LS_SHOW_SCRIPT_NAME', 'false'), FILTER_VALIDATE_BOOLEAN),
+        ],
+        'request' => [
+            'baseUrl' => $getenvOrDefault('LS_BASE_URL'),
+        ],
+    ],
+    'config' => [
+        'publicurl' => $getenvOrDefault('LS_PUBLIC_URL'),
+        'debug' => (int)$getenvOrDefault('LS_DEBUG_LEVEL', '0'),
+        'debugsql' => (int)$getenvOrDefault('LS_DEBUG_SQL_LEVEL', '0'),
+        'mysqlEngine' => $getenvOrDefault('LS_DB_DRIVER') === 'mysql' ? 'InnoDB' : '',
+    ],
+];
+
+$content = "<?php if (!defined('BASEPATH')) exit('No direct script access allowed');\nreturn " . var_export($config, true) . ";\n";
+if (file_put_contents($configPath, $content) === false) {
+    fwrite(STDERR, "Failed to write LimeSurvey configuration\n");
+    exit(1);
+}
+PHP
+else
+    log "config.php already present"
+fi
+
+ADMIN_USER=${ADMIN_USER:-admin}
+ADMIN_NAME=${ADMIN_NAME:-LimeSurvey Admin}
+ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
+ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
+ADMIN_PASSWORD_GENERATED=false
+if [[ -z "$ADMIN_PASSWORD" ]]; then
+    ADMIN_PASSWORD=$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20)
+    ADMIN_PASSWORD_GENERATED=true
+fi
+
+# Run database migrations / install
+log "Ensuring LimeSurvey database schema is up to date"
+if php application/commands/console.php updatedb; then
+    log "Database already provisioned"
+else
+    log "Running initial LimeSurvey installation"
+    php application/commands/console.php install "$ADMIN_USER" "$ADMIN_PASSWORD" "$ADMIN_NAME" "$ADMIN_EMAIL"
+    if [[ "$ADMIN_PASSWORD_GENERATED" == "true" ]]; then
+        cat <<MSG
+====================================================================
+LimeSurvey admin credentials
+    Username: $ADMIN_USER
+    Password: $ADMIN_PASSWORD
+Please store these securely. You can change them after first login.
+====================================================================
+MSG
+    fi
+fi
+
+exec "$@"

--- a/azure/vhosts-access-log.conf
+++ b/azure/vhosts-access-log.conf
@@ -1,0 +1,3 @@
+SetEnvIF User-Agent "(?i)(check|health|probe)" dontlog
+ErrorLog ${APACHE_LOG_DIR}/error.log
+CustomLog ${APACHE_LOG_DIR}/access.log combined env=!dontlog


### PR DESCRIPTION
## Summary
- add azure/Dockerfile with PHP 8.2, Microsoft ODBC driver and LimeSurvey 6.15.11
- add connection-string parser and entrypoint that install LimeSurvey from a single DB_CONNECTION_STRING
- document usage, options, and Azure deployment guidance

## Testing
- docker build -f azure/Dockerfile -t limesurvey-azure-test .
- docker run --rm --entrypoint dpkg limesurvey-azure-test -l msodbcsql18
